### PR TITLE
Rename the constants to be private.

### DIFF
--- a/adafruit_scd4x.py
+++ b/adafruit_scd4x.py
@@ -26,7 +26,6 @@ Implementation Notes
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
 
-# imports
 import time
 import struct
 import adafruit_bus_device.i2c_device as i2c_device
@@ -37,23 +36,23 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SCD4X.git"
 
 SCD4X_DEFAULT_ADDR = 0x62
-SCD4X_REINIT = const(0x3646)
-SCD4X_FACTORYRESET = const(0x3632)
-SCD4X_FORCEDRECAL = const(0x362F)
-SCD4X_SELFTEST = const(0x3639)
-SCD4X_DATAREADY = const(0xE4B8)
-SCD4X_STOPPERIODICMEASUREMENT = const(0x3F86)
-SCD4X_STARTPERIODICMEASUREMENT = const(0x21B1)
-SCD4X_READMEASUREMENT = const(0xEC05)
-SCD4X_SERIALNUMBER = const(0x3682)
-SCD4X_GETTEMPOFFSET = const(0x2318)
-SCD4X_SETTEMPOFFSET = const(0x241D)
-SCD4X_GETALTITUDE = const(0x2322)
-SCD4X_SETALTITUDE = const(0x2427)
-SCD4X_SETPRESSURE = const(0xE000)
-SCD4X_PERSISTSETTINGS = const(0x3615)
-SCD4X_GETASCE = const(0x2313)
-SCD4X_SETASCE = const(0x2416)
+_SCD4X_REINIT = const(0x3646)
+_SCD4X_FACTORYRESET = const(0x3632)
+_SCD4X_FORCEDRECAL = const(0x362F)
+_SCD4X_SELFTEST = const(0x3639)
+_SCD4X_DATAREADY = const(0xE4B8)
+_SCD4X_STOPPERIODICMEASUREMENT = const(0x3F86)
+_SCD4X_STARTPERIODICMEASUREMENT = const(0x21B1)
+_SCD4X_READMEASUREMENT = const(0xEC05)
+_SCD4X_SERIALNUMBER = const(0x3682)
+_SCD4X_GETTEMPOFFSET = const(0x2318)
+_SCD4X_SETTEMPOFFSET = const(0x241D)
+_SCD4X_GETALTITUDE = const(0x2322)
+_SCD4X_SETALTITUDE = const(0x2427)
+_SCD4X_SETPRESSURE = const(0xE000)
+_SCD4X_PERSISTSETTINGS = const(0x3615)
+_SCD4X_GETASCE = const(0x2313)
+_SCD4X_SETASCE = const(0x2416)
 
 
 class SCD4X:
@@ -146,18 +145,18 @@ class SCD4X:
     def reinit(self):
         """Reinitializes the sensor by reloading user settings from EEPROM."""
         self.stop_periodic_measurement()
-        self._send_command(SCD4X_REINIT, cmd_delay=0.02)
+        self._send_command(_SCD4X_REINIT, cmd_delay=0.02)
 
     def factory_reset(self):
         """Resets all configuration settings stored in the EEPROM and erases the
         FRC and ASC algorithm history."""
         self.stop_periodic_measurement()
-        self._send_command(SCD4X_FACTORYRESET, cmd_delay=1.2)
+        self._send_command(_SCD4X_FACTORYRESET, cmd_delay=1.2)
 
     def force_calibration(self, target_co2):
         """Forces the sensor to recalibrate with a given current CO2"""
         self.stop_periodic_measurement()
-        self._set_command_value(SCD4X_FORCEDRECAL, target_co2)
+        self._set_command_value(_SCD4X_FORCEDRECAL, target_co2)
         time.sleep(0.5)
         self._read_reply(self._buffer, 3)
         correction = struct.unpack_from(">h", self._buffer[0:2])[0]
@@ -178,25 +177,25 @@ class SCD4X:
             saved with persist_settings().
 
         """
-        self._send_command(SCD4X_GETASCE, cmd_delay=0.001)
+        self._send_command(_SCD4X_GETASCE, cmd_delay=0.001)
         self._read_reply(self._buffer, 3)
         return self._buffer[1] == 1
 
     @self_calibration_enabled.setter
     def self_calibration_enabled(self, enabled):
-        self._set_command_value(SCD4X_SETASCE, enabled)
+        self._set_command_value(_SCD4X_SETASCE, enabled)
 
     def self_test(self):
         """Performs a self test, takes up to 10 seconds"""
         self.stop_periodic_measurement()
-        self._send_command(SCD4X_SELFTEST, cmd_delay=10)
+        self._send_command(_SCD4X_SELFTEST, cmd_delay=10)
         self._read_reply(self._buffer, 3)
         if (self._buffer[0] != 0) or (self._buffer[1] != 0):
             raise RuntimeError("Self test failed")
 
     def _read_data(self):
         """Reads the temp/hum/co2 from the sensor and caches it"""
-        self._send_command(SCD4X_READMEASUREMENT, cmd_delay=0.001)
+        self._send_command(_SCD4X_READMEASUREMENT, cmd_delay=0.001)
         self._read_reply(self._buffer, 9)
         self._co2 = (self._buffer[0] << 8) | self._buffer[1]
         temp = (self._buffer[3] << 8) | self._buffer[4]
@@ -207,14 +206,14 @@ class SCD4X:
     @property
     def data_ready(self):
         """Check the sensor to see if new data is available"""
-        self._send_command(SCD4X_DATAREADY, cmd_delay=0.001)
+        self._send_command(_SCD4X_DATAREADY, cmd_delay=0.001)
         self._read_reply(self._buffer, 3)
         return not ((self._buffer[0] & 0x03 == 0) and (self._buffer[1] == 0))
 
     @property
     def serial_number(self):
         """Request a 6-tuple containing the unique serial number for this sensor"""
-        self._send_command(SCD4X_SERIALNUMBER, cmd_delay=0.001)
+        self._send_command(_SCD4X_SERIALNUMBER, cmd_delay=0.001)
         self._read_reply(self._buffer, 9)
         return (
             self._buffer[0],
@@ -227,21 +226,21 @@ class SCD4X:
 
     def stop_periodic_measurement(self):
         """Stop measurement mode"""
-        self._send_command(SCD4X_STOPPERIODICMEASUREMENT, cmd_delay=0.5)
+        self._send_command(_SCD4X_STOPPERIODICMEASUREMENT, cmd_delay=0.5)
 
     def start_periodic_measurement(self):
         """Put sensor into working mode, about 5s per measurement"""
-        self._send_command(SCD4X_STARTPERIODICMEASUREMENT, cmd_delay=0.01)
+        self._send_command(_SCD4X_STARTPERIODICMEASUREMENT, cmd_delay=0.01)
 
     def persist_settings(self):
         """Save temperature offset, altitude offset, and selfcal enable settings to EEPROM"""
-        self._send_command(SCD4X_PERSISTSETTINGS, cmd_delay=0.8)
+        self._send_command(_SCD4X_PERSISTSETTINGS, cmd_delay=0.8)
 
     def set_ambient_pressure(self, ambient_pressure):
         """Set the ambient pressure in hPa at any time to adjust CO2 calculations"""
         if ambient_pressure < 0 or ambient_pressure > 65535:
             raise AttributeError("`ambient_pressure` must be from 0~65535 hPascals")
-        self._set_command_value(SCD4X_SETPRESSURE, ambient_pressure)
+        self._set_command_value(_SCD4X_SETPRESSURE, ambient_pressure)
 
     @property
     def temperature_offset(self):
@@ -254,7 +253,7 @@ class SCD4X:
             persist_settings().
 
         """
-        self._send_command(SCD4X_GETTEMPOFFSET, cmd_delay=0.001)
+        self._send_command(_SCD4X_GETTEMPOFFSET, cmd_delay=0.001)
         self._read_reply(self._buffer, 3)
         temp = (self._buffer[0] << 8) | self._buffer[1]
         return 175.0 * temp / 2 ** 16
@@ -266,7 +265,7 @@ class SCD4X:
                 "Offset value must be less than or equal to 374 degrees Celsius"
             )
         temp = int(offset * 2 ** 16 / 175)
-        self._set_command_value(SCD4X_SETTEMPOFFSET, temp)
+        self._set_command_value(_SCD4X_SETTEMPOFFSET, temp)
 
     @property
     def altitude(self):
@@ -278,7 +277,7 @@ class SCD4X:
             This value will NOT be saved and will be reset on boot unless saved with
             persist_settings().
         """
-        self._send_command(SCD4X_GETALTITUDE, cmd_delay=0.001)
+        self._send_command(_SCD4X_GETALTITUDE, cmd_delay=0.001)
         self._read_reply(self._buffer, 3)
         return (self._buffer[0] << 8) | self._buffer[1]
 
@@ -286,7 +285,7 @@ class SCD4X:
     def altitude(self, height):
         if height > 65535:
             raise AttributeError("Height must be less than or equal to 65535 meters")
-        self._set_command_value(SCD4X_SETALTITUDE, height)
+        self._set_command_value(_SCD4X_SETALTITUDE, height)
 
     def _check_buffer_crc(self, buf):
         for i in range(0, len(buf), 3):
@@ -296,7 +295,7 @@ class SCD4X:
                 raise RuntimeError("CRC check failed while reading data")
         return True
 
-    def _send_command(self, cmd, cmd_delay=0):
+    def _send_command(self, cmd: int, cmd_delay: float = 0) -> None:
         self._cmd[0] = (cmd >> 8) & 0xFF
         self._cmd[1] = cmd & 0xFF
 


### PR DESCRIPTION
Based on a comment on the Scott & Jimmo deep-dive stream, private constants get treated different and use less space in the .mpy file because of not having to store the name of the constant.

```
CircuitPython 6 MPY
Before 6595 bytes
After  6113 bytes
Saving  482 bytes

CircuitPython 7 MPY
Before 3671 bytes
After  3234 bytes
Saving  437 bytes
```