### PR TITLE
Add start low power periodic measurement

### DIFF
--- a/adafruit_scd4x.py
+++ b/adafruit_scd4x.py
@@ -43,6 +43,7 @@ _SCD4X_SELFTEST = const(0x3639)
 _SCD4X_DATAREADY = const(0xE4B8)
 _SCD4X_STOPPERIODICMEASUREMENT = const(0x3F86)
 _SCD4X_STARTPERIODICMEASUREMENT = const(0x21B1)
+_SCD4X_STARTLOWPOWERPERIODICMEASUREMENT = const(0x21AC)
 _SCD4X_READMEASUREMENT = const(0xEC05)
 _SCD4X_SERIALNUMBER = const(0x3682)
 _SCD4X_GETTEMPOFFSET = const(0x2318)
@@ -230,6 +231,10 @@ class SCD4X:
     def start_periodic_measurement(self):
         """Put sensor into working mode, about 5s per measurement"""
         self._send_command(_SCD4X_STARTPERIODICMEASUREMENT, cmd_delay=0.01)
+
+    def start_low_periodic_measurement(self):
+        """Put sensor into low power working mode, about 30s per measurement"""
+        self._send_command(_SCD4X_STARTLOWPOWERPERIODICMEASUREMENT, cmd_delay=0.01)
 
     def persist_settings(self):
         """Save temperature offset, altitude offset, and selfcal enable settings to EEPROM"""

--- a/adafruit_scd4x.py
+++ b/adafruit_scd4x.py
@@ -230,11 +230,11 @@ class SCD4X:
 
     def start_periodic_measurement(self):
         """Put sensor into working mode, about 5s per measurement"""
-        self._send_command(_SCD4X_STARTPERIODICMEASUREMENT, cmd_delay=0.01)
+        self._send_command(_SCD4X_STARTPERIODICMEASUREMENT)
 
     def start_low_periodic_measurement(self):
         """Put sensor into low power working mode, about 30s per measurement"""
-        self._send_command(_SCD4X_STARTLOWPOWERPERIODICMEASUREMENT, cmd_delay=0.01)
+        self._send_command(_SCD4X_STARTLOWPOWERPERIODICMEASUREMENT)
 
     def persist_settings(self):
         """Save temperature offset, altitude offset, and selfcal enable settings to EEPROM"""


### PR DESCRIPTION
Saw this command in the data sheet and wanted to use it.
The function name is `start_low_periodic_measurement` instead of `start_low_power_periodic_measurement` to fit the length pylint wants.

Tested with a Feather RP2040 and the new SCD40 STEMMA QT breakout. Around 30 seconds between measurements.
![Screen Shot 2021-08-19 at 23 06 48](https://user-images.githubusercontent.com/3087025/130192260-ae0567d2-7633-40af-bb29-ab59c7cc72b5.png)

First time submitter! Hope I'm not missing anything.