### PR TITLE
Clearer error printout for I2C communication error

### DIFF
--- a/adafruit_scd4x.py
+++ b/adafruit_scd4x.py
@@ -234,15 +234,15 @@ class SCD4X:
         .. note::
             Only the following commands will work once in working mode:
 
-            * `SCD4X.CO2`
-            * `SCD4X.temperature`
-            * `SCD4X.relative_humidity`
-            * `SCD4x.data_ready()`
-            * `SCD4X.reinit()`
-            * `SCD4X.factory_reset()`
-            * `SCD4X.force_calibration()`
-            * `SCD4X.self_test()`
-            * `SCD4X.set_ambient_pressure()`
+            * :attr:`CO2 <adafruit_scd4x.SCD4X.CO2>`
+            * :attr:`temperature <adafruit_scd4x.SCD4X.temperature>`
+            * :attr:`relative_humidity <adafruit_scd4x.SCD4X.relative_humidity>`
+            * :meth:`data_ready() <adafruit_scd4x.SCD4x.data_ready>`
+            * :meth:`reinit() <adafruit_scd4x.SCD4X.reinit>`
+            * :meth:`factory_reset() <adafruit_scd4x.SCD4X.factory_reset>`
+            * :meth:`force_calibration() <adafruit_scd4x.SCD4X.force_calibration>`
+            * :meth:`self_test() <adafruit_scd4x.SCD4X.self_test>`
+            * :meth:`set_ambient_pressure() <adafruit_scd4x.SCD4X.set_ambient_pressure>`
 
         """
         self._send_command(_SCD4X_STARTPERIODICMEASUREMENT)

--- a/adafruit_scd4x.py
+++ b/adafruit_scd4x.py
@@ -249,7 +249,8 @@ class SCD4X:
 
     def start_low_periodic_measurement(self):
         """Put sensor into low power working mode, about 30s per measurement. See
-        `SCD4X.start_perodic_measurement` for more details.
+        :meth:`start_periodic_measurement() <adafruit_scd4x.SCD4X.start_perodic_measurement>`
+        for more details.
         """
         self._send_command(_SCD4X_STARTLOWPOWERPERIODICMEASUREMENT)
 

--- a/adafruit_scd4x.py
+++ b/adafruit_scd4x.py
@@ -326,8 +326,8 @@ class SCD4X:
                 i2c.write(self._cmd, end=2)
         except OSError as err:
             raise RuntimeError(
-                "Could not communicate via I2C, some commands/settings \
-                    unavailable while in working mode"
+                "Could not communicate via I2C, some commands/settings "
+                "unavailable while in working mode"
             ) from err
         time.sleep(cmd_delay)
 


### PR DESCRIPTION
Resolves #10 by:

1. Transforming the `OSError` into a `RuntimeError` that explains that some commands are unavailable in working mode.  Still mentions it as an I2C communication just in case it really is
2. Referenced the datasheet to add the list of commands that should work while in working mode to the docstring of `start_periodic_measurement()` (and a reference to that in `start_low_periodic_measurement()`) to help clarify.

Not tested yet, but wanted to know if this is the right solution