### PR TITLE
Fix force_calibration return value and reinit wait time

### DIFF
--- a/adafruit_scd4x.py
+++ b/adafruit_scd4x.py
@@ -164,7 +164,8 @@ class SCD4X:
     def reinit(self) -> None:
         """Reinitializes the sensor by reloading user settings from EEPROM."""
         self.stop_periodic_measurement()
-        self._send_command(_SCD4X_REINIT, cmd_delay=0.02)
+        # Execution time raised from 20 ms to 30 ms in the v1.7 datasheet (Table 30).
+        self._send_command(_SCD4X_REINIT, cmd_delay=0.03)
 
     def factory_reset(self) -> None:
         """Resets all configuration settings stored in the EEPROM and erases the
@@ -172,18 +173,28 @@ class SCD4X:
         self.stop_periodic_measurement()
         self._send_command(_SCD4X_FACTORYRESET, cmd_delay=1.2)
 
-    def force_calibration(self, target_co2: int) -> None:
-        """Forces the sensor to recalibrate with a given current CO2"""
+    def force_calibration(self, target_co2: int) -> int:
+        """Forces the sensor to recalibrate to a known CO2 level in PPM.
+
+        Returns the FRC correction the sensor applied, in PPM (this value may be
+        negative). Before calling, the sensor must have been operated in a
+        measurement mode for more than 3 minutes in a stable, homogeneous CO2
+        environment, otherwise the recalibration will fail.
+
+        :raises RuntimeError: if the sensor reports that the recalibration failed.
+        """
         self.stop_periodic_measurement()
         self._set_command_value(_SCD4X_FORCEDRECAL, target_co2)
         time.sleep(0.5)
         self._read_reply(self._buffer, 3)
-        correction = struct.unpack_from(">h", self._buffer[0:2])[0]
+        # The raw word is unsigned; a value of 0xffff signals a failed FRC, and
+        # the correction is the raw word minus the 0x8000 bias (datasheet 3.8.1).
+        correction = struct.unpack_from(">H", self._buffer[0:2])[0]
         if correction == 0xFFFF:
             raise RuntimeError(
-                "Forced recalibration failed.\
-            Make sure sensor is active for 3 minutes first"
+                "Forced recalibration failed. Make sure sensor is active for 3 minutes first"
             )
+        return correction - 0x8000
 
     @property
     def self_calibration_enabled(self) -> bool:


### PR DESCRIPTION
_I have a second PR with enhancements that I'll submit after this one gets merged as recommended by Tim._

**Force Calibration fix**

Force_calibration was comparing a signed value and it will always fail the comparison with 0xFFFF to indicate an improperly conditioned sensor.  V1.7 Datasheet says to check return for value 0xFFFF which is an error.  Otherwise returned value indicates signed correction by (ret - 0x8000).  It was not returning anything and it would be good to return the signed correction.  Datasheet section 3.8.1

**Decision point:** I know a force_calibration is probably going to be done via manual or at least supervised conditions.  I raised a runtime error for the condition.  The other possibility would be to return 0xFFFF to match the datasheet and the programmer could just check for that.  Unfortunately it would look like 65535 which is a weird correction value.

**Reinit wait time fix**

Fix reinit 30ms vs 20ms per V1.7 datasheet (changed since earlier datasheets) section 3.10.5

**Testing**
Here is the broken force_calibration behavior -- this should have been an error (must condition first before calibrating):

```
Adafruit CircuitPython 10.2.1 on 2026-05-13; Adafruit Feather ESP32S3 4MB Flash 2MB PSRAM with ESP32S3
>>> # SCD40
>>> import board
>>> import time
>>> import adafruit_scd4x
>>> i2c = board.I2C()
>>> scd = adafruit_scd4x.SCD4X(i2c)
>>> scd.reinit()
>>> scd.force_calibration(603)
>>> # This should have returned an error because of being done right after reinit
```

**Corrected and New behavior**

```
Adafruit CircuitPython 10.2.1 on 2026-05-13; Adafruit Feather ESP32S3 4MB Flash 2MB PSRAM with ESP32S3
>>> # SCD40
>>> import board
>>> import time
>>> import adafruit_scd4x_pr1
>>> i2c = board.I2C()
>>> scd = adafruit_scd4x_pr1.SCD4X(i2c)
>>> scd.force_calibration(670)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "adafruit_scd4x_pr1.py", line 195, in force_calibration
RuntimeError: Forced recalibration failed. Make sure sensor is active for 3 minutes first
>>> scd.start_periodic_measurement()
>>> time.sleep(180)
>>> scd.force_calibration(670)
135
>>> scd.force_calibration(450)
-220
>>>
```